### PR TITLE
Visitor improvements

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3403,7 +3403,11 @@ impl fmt::Display for Assignment {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(
+    feature = "visitor",
+    derive(Visit, VisitMut),
+    visit(with = "visit_function_arg")
+)]
 pub enum FunctionArgExpr {
     Expr(Expr),
     /// Qualified wildcard, e.g. `alias.*` or `schema.table.*`.

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -73,7 +73,11 @@ impl fmt::Display for Query {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(
+    feature = "visitor",
+    derive(Visit, VisitMut),
+    visit(with = "visit_setexpr")
+)]
 pub enum SetExpr {
     /// Restricted SELECT .. FROM .. HAVING (no ORDER BY or set operations)
     Select(Box<Select>),


### PR DESCRIPTION
### Set Expression Visitor
Adds visitors for set expressions such as UNION, EXCEPT etc. This allows rewriting them. For instance we need to rewrite `UNION` to `UNION DISTINCT` in BQ peer.

### Function Argument Visitor
Fixes this by including the configuration attribute for `FunctionArgExpr` type. This enables implementing a visitor-based solution for issues related to function arguments.