### PR TITLE
Add CockroachDB PeerType support

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2877,6 +2877,7 @@ pub enum PeerType {
     PubSub,
     Elasticsearch,
     Clickhouse,
+    CockroachDB,
 }
 
 impl fmt::Display for PeerType {
@@ -2894,6 +2895,7 @@ impl fmt::Display for PeerType {
             PeerType::PubSub => write!(f, "PUBSUB"),
             PeerType::Elasticsearch => write!(f, "ELASTICSEARCH"),
             PeerType::Clickhouse => write!(f, "CLICKHOUSE"),
+            PeerType::CockroachDB => write!(f, "COCKROACHDB"),
         }
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -153,6 +153,7 @@ define_keywords!(
     CLOSE,
     CLUSTER,
     COALESCE,
+    COCKROACHDB,
     COLLATE,
     COLLATION,
     COLLECT,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9829,6 +9829,7 @@ impl<'a> Parser<'a> {
             Keyword::PUBSUB,
             Keyword::ELASTICSEARCH,
             Keyword::CLICKHOUSE,
+            Keyword::COCKROACHDB,
         ]) {
             Some(Keyword::BIGQUERY) => Ok(PeerType::Bigquery),
             Some(Keyword::MONGO) => Ok(PeerType::Mongo),
@@ -9842,6 +9843,7 @@ impl<'a> Parser<'a> {
             Some(Keyword::PUBSUB) => Ok(PeerType::PubSub),
             Some(Keyword::ELASTICSEARCH) => Ok(PeerType::Elasticsearch),
             Some(Keyword::CLICKHOUSE) => Ok(PeerType::Clickhouse),
+            Some(Keyword::COCKROACHDB) => Ok(PeerType::CockroachDB),
             other => {
                 let supported_peer_types = [
                     "BIGQUERY",
@@ -9856,6 +9858,7 @@ impl<'a> Parser<'a> {
                     "PUBSUB",
                     "ELASTICSEARCH",
                     "CLICKHOUSE",
+                    "COCKROACHDB",
                 ];
                 let err = format!(
                     "expected peertype as one of {}, got {:#?}",


### PR DESCRIPTION
Added CockroachDB as a supported peer type following the same pattern as other database types (ClickHouse, Elasticsearch, etc.). This enables PeerDB integration with CockroachDB.

## Changes
- Added COCKROACHDB keyword to `src/keywords.rs`
- Added CockroachDB variant to PeerType enum in `src/ast/mod.rs`
- Updated Display impl for PeerType
- Updated parse_peer_type function in `src/parser/mod.rs`

## Testing
- All existing tests pass
- Code formatted with `cargo fmt`